### PR TITLE
feat: implement meme coin creation API and setup migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # env file
 .env
+
+# macOS folder metadata
+.DS_Store

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,24 +5,15 @@ import (
 	"log"
 
 	"github.com/HackHow/meme-coin/config"
+	"github.com/HackHow/meme-coin/internal/routers"
 	"github.com/HackHow/meme-coin/pkg/database"
-
-	"github.com/gin-gonic/gin"
 )
 
 func main() {
 	config.LoadConfig()
 	database.InitDB()
 
-	router := gin.Default()
-
-	router.GET("/", func(c *gin.Context) {
-		c.JSON(200, gin.H{
-			"code":    200,
-			"message": "Welcome to Meme Coin API!",
-			"data":    nil,
-		})
-	})
+	router := routers.InitRouter()
 
 	port := config.AppConfig.ServerPort
 	if port == "" {

--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/HackHow/meme-coin/internal/model"
+	"github.com/HackHow/meme-coin/internal/service"
+	"github.com/gin-gonic/gin"
+	"log"
+	"net/http"
+)
+
+func CreateMemeCoin(c *gin.Context) {
+	var coin model.MemeCoin
+	if err := c.ShouldBindJSON(&coin); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "Invalid request payload",
+			"data":    nil,
+		})
+		return
+	}
+
+	if err := service.CreateMemeCoin(&coin); err != nil {
+		log.Printf("Failed to create meme coin: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    500,
+			"message": "Failed to create meme coin",
+			"data":    nil,
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"code":    201,
+		"message": "Meme coin created successfully",
+		"data":    coin,
+	})
+}

--- a/internal/model/meme_coin.go
+++ b/internal/model/meme_coin.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"time"
+)
+
+type MemeCoin struct {
+	ID              uint      `gorm:"primaryKey;autoIncrement" json:"id"`   // The unique identifier of a meme coin.
+	Name            string    `gorm:"unique;not null" json:"name"`          // The name of the meme coin. Must be unique across all coins and cannot be empty.
+	Description     string    `gorm:"type:varchar(255)" json:"description"` // A brief description of the meme coin.
+	CreatedAt       time.Time `gorm:"autoCreateTime" json:"created_at"`     // The timestamp when the meme coin was created.
+	PopularityScore int       `gorm:"default:0" json:"popularity_score"`    // A score representing the popularity of the meme coin.
+}

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -1,0 +1,10 @@
+package repository
+
+import (
+	"github.com/HackHow/meme-coin/internal/model"
+	"github.com/HackHow/meme-coin/pkg/database"
+)
+
+func CreateMemeCoin(coin *model.MemeCoin) error {
+	return database.DB.Create(coin).Error
+}

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -1,0 +1,15 @@
+package routers
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/HackHow/meme-coin/internal/handler"
+)
+
+func InitRouter() *gin.Engine {
+	r := gin.Default()
+
+	r.POST("/meme-coins", handler.CreateMemeCoin)
+
+	return r
+}

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -1,0 +1,10 @@
+package service
+
+import (
+	"github.com/HackHow/meme-coin/internal/model"
+	"github.com/HackHow/meme-coin/internal/repository"
+)
+
+func CreateMemeCoin(coin *model.MemeCoin) error {
+	return repository.CreateMemeCoin(coin)
+}

--- a/migrations/20250329134617_create_meme_coins_table.down.sql
+++ b/migrations/20250329134617_create_meme_coins_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS meme_coins;

--- a/migrations/20250329134617_create_meme_coins_table.up.sql
+++ b/migrations/20250329134617_create_meme_coins_table.up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS meme_coins
+(
+    id               SERIAL PRIMARY KEY,
+    name             VARCHAR(255) UNIQUE NOT NULL,
+    description      VARCHAR(255),
+    created_at       TIMESTAMP           NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    popularity_score INTEGER                      DEFAULT 0
+);


### PR DESCRIPTION
# What

1. Added migration files to create `meme_coins` table using golang-migrate.
2. Implemented create meme coin API with full layered architecture:
   - Model, repository, service, handler
3. Created a router module and registered routes separately from main.go.
4. Updated .gitignore to include `.DS_Store`.

# Why

1. To initialize DB schema and enable version-controlled migrations.
2. To support meme coin creation through a clean and extensible API structure.
3. To enforce clearer architectural separation between entry point and route setup.
4. To avoid committing local system files.
