### PR TITLE
feat: add get meme coin API with versioned routing and DTO support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 DB_NAME=your_db_name
 SERVER_PORT=8080
+
+API_VERSION=v1

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	DBPassword string
 	DBName     string
 	ServerPort string
+	APIVersion string
 }
 
 var AppConfig Config
@@ -31,5 +32,6 @@ func LoadConfig() {
 		DBPassword: os.Getenv("DB_PASSWORD"),
 		DBName:     os.Getenv("DB_NAME"),
 		ServerPort: os.Getenv("SERVER_PORT"),
+		APIVersion: os.Getenv("API_VERSION"),
 	}
 }

--- a/internal/dtos/meme_coin_dto.go
+++ b/internal/dtos/meme_coin_dto.go
@@ -1,0 +1,10 @@
+package dtos
+
+import "time"
+
+type GetMemeCoinResponse struct {
+	Name            string    `json:"name"`
+	Description     string    `json:"description"`
+	CreatedAt       time.Time `json:"created_at"`
+	PopularityScore int       `json:"popularity_score"`
+}

--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -1,11 +1,17 @@
 package handler
 
 import (
-	"github.com/HackHow/meme-coin/internal/model"
-	"github.com/HackHow/meme-coin/internal/service"
-	"github.com/gin-gonic/gin"
+	"fmt"
+
 	"log"
 	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/HackHow/meme-coin/internal/dtos"
+	"github.com/HackHow/meme-coin/internal/model"
+	"github.com/HackHow/meme-coin/internal/service"
 )
 
 func CreateMemeCoin(c *gin.Context) {
@@ -33,5 +39,45 @@ func CreateMemeCoin(c *gin.Context) {
 		"code":    201,
 		"message": "Meme coin created successfully",
 		"data":    coin,
+	})
+}
+
+func GetMemeCoin(c *gin.Context) {
+	idStr := c.Param("id")
+	fmt.Print("idStr:", idStr)
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "Invalid meme coin ID",
+			"data":    nil,
+		})
+		return
+	}
+
+	coin, err := service.GetMemeCoin(uint(id))
+	fmt.Print("coin:", coin)
+	fmt.Print("err:", err)
+	if err != nil {
+		log.Printf("Failed to get meme coin: %v", err)
+		c.JSON(http.StatusNotFound, gin.H{
+			"code":    404,
+			"message": "Meme coin not found",
+			"data":    nil,
+		})
+		return
+	}
+
+	response := dtos.GetMemeCoinResponse{
+		Name:            coin.Name,
+		Description:     coin.Description,
+		CreatedAt:       coin.CreatedAt,
+		PopularityScore: coin.PopularityScore,
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    200,
+		"message": "Meme coin details fetched successfully",
+		"data":    response,
 	})
 }

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -8,3 +8,12 @@ import (
 func CreateMemeCoin(coin *model.MemeCoin) error {
 	return database.DB.Create(coin).Error
 }
+
+func GetMemeCoin(id uint) (*model.MemeCoin, error) {
+	var coin model.MemeCoin
+	if err := database.DB.First(&coin, id).Error; err != nil {
+		return nil, err
+	}
+
+	return &coin, nil
+}

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -10,6 +10,7 @@ func InitRouter() *gin.Engine {
 	r := gin.Default()
 
 	r.POST("/meme-coins", handler.CreateMemeCoin)
+	r.GET("/meme-coins/:id", handler.GetMemeCoin)
 
 	return r
 }

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -3,14 +3,18 @@ package routers
 import (
 	"github.com/gin-gonic/gin"
 
+	"github.com/HackHow/meme-coin/config"
 	"github.com/HackHow/meme-coin/internal/handler"
 )
 
 func InitRouter() *gin.Engine {
 	r := gin.Default()
 
-	r.POST("/meme-coins", handler.CreateMemeCoin)
-	r.GET("/meme-coins/:id", handler.GetMemeCoin)
+	api := r.Group("/api/" + config.AppConfig.APIVersion)
+	{
+		api.POST("/meme-coins", handler.CreateMemeCoin)
+		api.GET("/meme-coins/:id", handler.GetMemeCoin)
+	}
 
 	return r
 }

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -8,3 +8,7 @@ import (
 func CreateMemeCoin(coin *model.MemeCoin) error {
 	return repository.CreateMemeCoin(coin)
 }
+
+func GetMemeCoin(id uint) (*model.MemeCoin, error) {
+	return repository.GetMemeCoin(id)
+}


### PR DESCRIPTION
# What

1. Added a new API to fetch meme coin details by ID.
2. Introduced `internal/dtos/` with `MemeCoinDTO` to format response structure.
3. Added `API_VERSION` to config and .env.example for route versioning.
4. Refactored router using `Group()` to organize routes by category.

# Why

1. To allow clients to retrieve meme coin data by its ID.
2. To decouple internal data model from API layer with DTO abstraction.
3. To prepare for future API versioning and maintain clean route organization.
