### PR TITLE
feat: implement delete meme coin API

### DIFF
--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -120,3 +120,32 @@ func UpdateMemeCoin(c *gin.Context) {
 		"data":    nil,
 	})
 }
+
+func DeleteMemeCoin(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "Invalid meme coin ID",
+			"data":    nil,
+		})
+		return
+	}
+
+	if err := service.DeleteMemeCoin(uint(id)); err != nil {
+		log.Printf("Failed to delete meme coin: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    500,
+			"message": "Failed to delete meme coin",
+			"data":    nil,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    200,
+		"message": "Meme coin deleted successfully",
+		"data":    gin.H{"id": id},
+	})
+}

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -21,3 +21,7 @@ func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 func UpdateMemeCoin(id uint, description string) error {
 	return database.DB.Model(&model.MemeCoin{}).Where("id = ?", id).Update("description", description).Error
 }
+
+func DeleteMemeCoin(id uint) error {
+	return database.DB.Delete(&model.MemeCoin{}, id).Error
+}

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -15,6 +15,7 @@ func InitRouter() *gin.Engine {
 		api.POST("/meme-coins", handler.CreateMemeCoin)
 		api.GET("/meme-coins/:id", handler.GetMemeCoin)
 		api.PATCH("/meme-coins/:id", handler.UpdateMemeCoin)
+		api.DELETE("/meme-coins/:id", handler.DeleteMemeCoin)
 	}
 
 	return r

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -16,3 +16,7 @@ func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 func UpdateMemeCoin(id uint, description string) error {
 	return repository.UpdateMemeCoin(id, description)
 }
+
+func DeleteMemeCoin(id uint) error {
+	return repository.DeleteMemeCoin(id)
+}


### PR DESCRIPTION
# What

1. Implemented Delete Meme Coin API to remove a meme coin by its ID.
2. Updated handler, service, and repository layers accordingly.
3. Registered the route in the router module.

# Why

1. To provide clients with the ability to remove meme coin records.
2. To complete the basic CRUD operations for the meme coin resource.