### PR TITLE
feat: implement poke meme coin API

### DIFF
--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"fmt"
-
 	"log"
 	"net/http"
 	"strconv"
@@ -44,7 +42,6 @@ func CreateMemeCoin(c *gin.Context) {
 
 func GetMemeCoin(c *gin.Context) {
 	idStr := c.Param("id")
-	fmt.Print("idStr:", idStr)
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -56,8 +53,6 @@ func GetMemeCoin(c *gin.Context) {
 	}
 
 	coin, err := service.GetMemeCoin(uint(id))
-	fmt.Print("coin:", coin)
-	fmt.Print("err:", err)
 	if err != nil {
 		log.Printf("Failed to get meme coin: %v", err)
 		c.JSON(http.StatusNotFound, gin.H{
@@ -147,5 +142,34 @@ func DeleteMemeCoin(c *gin.Context) {
 		"code":    200,
 		"message": "Meme coin deleted successfully",
 		"data":    gin.H{"id": id},
+	})
+}
+
+func PokeMemeCoin(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"code":    400,
+			"message": "Invalid meme coin ID",
+			"data":    nil,
+		})
+		return
+	}
+
+	if err := service.PokeMemeCoin(uint(id)); err != nil {
+		log.Printf("Failed to poke meme coin: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"code":    500,
+			"message": "Failed to poke meme coin",
+			"data":    nil,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"code":    200,
+		"message": "Meme coin poked successfully",
+		"data":    nil,
 	})
 }

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"github.com/HackHow/meme-coin/internal/model"
 	"github.com/HackHow/meme-coin/pkg/database"
+	"gorm.io/gorm"
 )
 
 func CreateMemeCoin(coin *model.MemeCoin) error {
@@ -24,4 +25,10 @@ func UpdateMemeCoin(id uint, description string) error {
 
 func DeleteMemeCoin(id uint) error {
 	return database.DB.Delete(&model.MemeCoin{}, id).Error
+}
+
+func PokeMemeCoin(id uint) error {
+	return database.DB.Model(&model.MemeCoin{}).
+		Where("id = ?", id).
+		UpdateColumn("popularity_score", gorm.Expr("popularity_score + ?", 1)).Error
 }

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -16,6 +16,7 @@ func InitRouter() *gin.Engine {
 		api.GET("/meme-coins/:id", handler.GetMemeCoin)
 		api.PATCH("/meme-coins/:id", handler.UpdateMemeCoin)
 		api.DELETE("/meme-coins/:id", handler.DeleteMemeCoin)
+		api.POST("/meme-coins/:id/poke", handler.PokeMemeCoin)
 	}
 
 	return r

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -20,3 +20,7 @@ func UpdateMemeCoin(id uint, description string) error {
 func DeleteMemeCoin(id uint) error {
 	return repository.DeleteMemeCoin(id)
 }
+
+func PokeMemeCoin(id uint) error {
+	return repository.PokeMemeCoin(id)
+}


### PR DESCRIPTION
# What

1. Implemented Poke Meme Coin API to increment a meme coin’s popularity score.
2. Added business logic in service layer and update method in repository.
3. Registered the route in the router for poke endpoint.

# Why

1. To provide an interactive action to increase meme coin visibility or popularity.
2. To support user engagement functionality in the application.
