### PR TITLE
chore: dockerize app and add DB wait logic for startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.gitignore
+
+README.md
+
+# Ignore docker-compose configuration file (typically used for local development and not needed in the build context)
+docker-compose.yaml
+
+# Ignore local environment variable files (if present)
+.env
+.DS_Store
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Build stage
+FROM golang:1.24.1-alpine AS builder
+WORKDIR /app
+
+# 安裝 git（如果需要）
+RUN apk update && apk add --no-cache git
+
+# 複製 go.mod 與 go.sum 並下載依賴
+COPY go.mod go.sum ./
+RUN go mod download
+
+# 複製所有程式碼到容器中
+COPY . .
+
+# 編譯應用程式，假設 main package 位於 cmd/server 目錄中
+RUN CGO_ENABLED=0 GOOS=linux go build -o meme-coin ./cmd/server
+
+# Run stage
+FROM alpine:latest
+WORKDIR /root/
+
+# 安裝 curl 與 unzip 並下載 migrate CLI
+RUN apk add --no-cache curl unzip && \
+    curl -L https://github.com/golang-migrate/migrate/releases/download/v4.18.2/migrate.linux-amd64.tar.gz | tar xvz -C /tmp && \
+    mv /tmp/migrate /migrate && \
+    chmod +x /migrate
+
+# 複製編譯後的二進位檔、migration 檔案與 entrypoint 脚本
+COPY --from=builder /app/meme-coin .
+COPY migrations /migrations
+COPY wait-for-it.sh entrypoint.sh /
+RUN chmod +x /wait-for-it.sh /entrypoint.sh
+
+EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,21 @@
-version: '3.8'
 services:
+  app:
+    build: meme-coin-app:latest
+    container_name: meme-coin-app
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+    environment:
+      ServerPort: ${SERVER_PORT}
+      API_VERSION: ${API_VERSION}
+      DB_HOST: postgres
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      DATABASE_URL: "postgres://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}?sslmode=disable"
+
   postgres:
     image: postgres:latest
     container_name: meme_coin_postgres

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+
+/wait-for-it.sh meme_coin_postgres:5432 --timeout=30 --strict -- echo "Database started successfully!"
+/migrate -path=/migrations -database="${DATABASE_URL}" up
+
+echo "Starting application..."
+exec ./meme-coin

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=$(basename "$0")
+
+echoerr() {
+  if [ "$WAITFORIT_QUIET" -ne 1 ]; then
+    echo "$@" 1>&2
+  fi
+}
+
+usage() {
+  cat <<USAGE 1>&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+  exit 1
+}
+
+wait_for() {
+  if [ "$WAITFORIT_TIMEOUT" -gt 0 ]; then
+    echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+  else
+    echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+  fi
+  WAITFORIT_start_ts=$(date +%s)
+  while :
+  do
+    if [ "$WAITFORIT_ISBUSY" -eq 1 ]; then
+      nc -z "$WAITFORIT_HOST" "$WAITFORIT_PORT"
+      WAITFORIT_result=$?
+    else
+      (echo -n > /dev/tcp/"$WAITFORIT_HOST"/"$WAITFORIT_PORT") >/dev/null 2>&1
+      WAITFORIT_result=$?
+    fi
+    if [ "$WAITFORIT_result" -eq 0 ]; then
+      WAITFORIT_end_ts=$(date +%s)
+      echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+      break
+    fi
+    sleep 1
+  done
+  return "$WAITFORIT_result"
+}
+
+wait_for_wrapper() {
+  if [ "$WAITFORIT_QUIET" -eq 1 ]; then
+    timeout $WAITFORIT_BUSYTIMEFLAG "$WAITFORIT_TIMEOUT" "$0" --quiet --child --host="$WAITFORIT_HOST" --port="$WAITFORIT_PORT" --timeout="$WAITFORIT_TIMEOUT" &
+  else
+    timeout $WAITFORIT_BUSYTIMEFLAG "$WAITFORIT_TIMEOUT" "$0" --child --host="$WAITFORIT_HOST" --port="$WAITFORIT_PORT" --timeout="$WAITFORIT_TIMEOUT" &
+  fi
+  WAITFORIT_PID=$!
+  trap "kill -INT -$WAITFORIT_PID" INT
+  wait "$WAITFORIT_PID"
+  WAITFORIT_RESULT=$?
+  if [ "$WAITFORIT_RESULT" -ne 0 ]; then
+    echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+  fi
+  return "$WAITFORIT_RESULT"
+}
+
+# 處理參數
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:*)
+      WAITFORIT_hostport=$(echo "$1" | sed 's/:/ /')
+      WAITFORIT_HOST=$(echo "$WAITFORIT_hostport" | awk '{print $1}')
+      WAITFORIT_PORT=$(echo "$WAITFORIT_hostport" | awk '{print $2}')
+      shift 1
+      ;;
+    --child)
+      WAITFORIT_CHILD=1
+      shift 1
+      ;;
+    -q|--quiet)
+      WAITFORIT_QUIET=1
+      shift 1
+      ;;
+    -s|--strict)
+      WAITFORIT_STRICT=1
+      shift 1
+      ;;
+    -h)
+      WAITFORIT_HOST="$2"
+      if [ -z "$WAITFORIT_HOST" ]; then break; fi
+      shift 2
+      ;;
+    --host=*)
+      WAITFORIT_HOST=$(echo "$1" | sed 's/--host=//')
+      shift 1
+      ;;
+    -p)
+      WAITFORIT_PORT="$2"
+      if [ -z "$WAITFORIT_PORT" ]; then break; fi
+      shift 2
+      ;;
+    --port=*)
+      WAITFORIT_PORT=$(echo "$1" | sed 's/--port=//')
+      shift 1
+      ;;
+    -t)
+      WAITFORIT_TIMEOUT="$2"
+      if [ -z "$WAITFORIT_TIMEOUT" ]; then break; fi
+      shift 2
+      ;;
+    --timeout=*)
+      WAITFORIT_TIMEOUT=$(echo "$1" | sed 's/--timeout=//')
+      shift 1
+      ;;
+    --)
+      shift
+      WAITFORIT_CLI="$@"
+      break 2
+      ;;
+    --help)
+      usage
+      ;;
+    *)
+      echoerr "Unknown argument: $1"
+      usage
+      ;;
+  esac
+done
+
+if [ -z "$WAITFORIT_HOST" ] || [ -z "$WAITFORIT_PORT" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+WAITFORIT_TIMEOUT_PATH=$(command -v timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath "$WAITFORIT_TIMEOUT_PATH" 2>/dev/null || readlink -f "$WAITFORIT_TIMEOUT_PATH")
+
+WAITFORIT_BUSYTIMEFLAG=""
+case "$WAITFORIT_TIMEOUT_PATH" in
+  *busybox*)
+    WAITFORIT_ISBUSY=1
+    if timeout --help 2>&1 | grep -q -- '-t '; then
+      WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+    ;;
+  *)
+    WAITFORIT_ISBUSY=0
+    ;;
+esac
+
+if [ "$WAITFORIT_CHILD" -gt 0 ]; then
+  wait_for
+  WAITFORIT_RESULT=$?
+  exit "$WAITFORIT_RESULT"
+else
+  if [ "$WAITFORIT_TIMEOUT" -gt 0 ]; then
+    wait_for_wrapper
+    WAITFORIT_RESULT=$?
+  else
+    wait_for
+    WAITFORIT_RESULT=$?
+  fi
+fi
+
+if [ -n "$WAITFORIT_CLI" ]; then
+  if [ "$WAITFORIT_RESULT" -ne 0 ] && [ "$WAITFORIT_STRICT" -eq 1 ]; then
+    echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+    exit "$WAITFORIT_RESULT"
+  fi
+  exec $WAITFORIT_CLI
+else
+  exit "$WAITFORIT_RESULT"
+fi


### PR DESCRIPTION
# What

1. Created Dockerfile to build the Go application image.
2. Added .dockerignore to reduce build context size.
3. Implemented entrypoint.sh to handle wait-for-db logic before starting the app.
4. Included wait-for-it.sh utility script.
5. Updated docker-compose.yaml to run app with entrypoint and wait mechanism.

# Why

1. To containerize the application for consistent runtime and deployment.
2. To prevent application from starting before PostgreSQL is fully ready.
3. To automate DB migration and app start-up sequence in local and CI environments.
