### PR TITLE
fix: handle not found error for meme coin and apply unified error format

### DIFF
--- a/internal/common/app_error.go
+++ b/internal/common/app_error.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AppError struct {
+	Code    int
+	Message string
+	Data    interface{}
+}
+
+func (e *AppError) Error() string {
+	return e.Message
+}
+
+func HandleError(c *gin.Context, err error) {
+	var appErr *AppError
+	if errors.As(err, &appErr) {
+		c.JSON(appErr.Code, gin.H{
+			"code":    appErr.Code,
+			"message": appErr.Message,
+			"data":    appErr.Data,
+		})
+		return
+	}
+
+	c.JSON(http.StatusInternalServerError, gin.H{
+		"code":    500,
+		"message": "Internal server error",
+		"data":    nil,
+	})
+}

--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/HackHow/meme-coin/internal/common"
 	"github.com/HackHow/meme-coin/internal/dtos"
 	"github.com/HackHow/meme-coin/internal/model"
 	"github.com/HackHow/meme-coin/internal/service"
@@ -81,31 +82,28 @@ func UpdateMemeCoin(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"code":    400,
-			"message": "Invalid meme coin ID",
-			"data":    nil,
+		common.HandleError(c, &common.AppError{
+			Code:    400,
+			Message: "Invalid meme coin ID",
+			Data:    nil,
 		})
 		return
 	}
 
 	var updateReq dtos.UpdateMemeCoinRequest
 	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"code":    400,
-			"message": "Invalid request payload",
-			"data":    nil,
+		common.HandleError(c, &common.AppError{
+			Code:    400,
+			Message: "Invalid request payload",
+			Data:    nil,
 		})
 		return
 	}
 
-	if err := service.UpdateMemeCoin(uint(id), updateReq.Description); err != nil {
+	err = service.UpdateMemeCoin(uint(id), updateReq.Description)
+	if err != nil {
 		log.Printf("Failed to update meme coin: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"code":    500,
-			"message": "Failed to update meme coin",
-			"data":    nil,
-		})
+		common.HandleError(c, err)
 		return
 	}
 

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -19,8 +19,10 @@ func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 	return &coin, nil
 }
 
-func UpdateMemeCoin(id uint, description string) error {
-	return database.DB.Model(&model.MemeCoin{}).Where("id = ?", id).Update("description", description).Error
+func UpdateMemeCoin(id uint, description string) *gorm.DB {
+	return database.DB.Model(&model.MemeCoin{}).
+		Where("id = ?", id).
+		Update("description", description)
 }
 
 func DeleteMemeCoin(id uint) error {

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/HackHow/meme-coin/internal/common"
 	"github.com/HackHow/meme-coin/internal/model"
 	"github.com/HackHow/meme-coin/internal/repository"
 )
@@ -14,7 +15,25 @@ func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 }
 
 func UpdateMemeCoin(id uint, description string) error {
-	return repository.UpdateMemeCoin(id, description)
+	result := repository.UpdateMemeCoin(id, description)
+
+	if result.Error != nil {
+		return &common.AppError{
+			Code:    500,
+			Message: "Database error",
+			Data:    nil,
+		}
+	}
+
+	if result.RowsAffected == 0 {
+		return &common.AppError{
+			Code:    404,
+			Message: "Meme coin not found",
+			Data:    nil,
+		}
+	}
+
+	return nil
 }
 
 func DeleteMemeCoin(id uint) error {


### PR DESCRIPTION
# What

1. Fixed an issue where API returned 200 even when a meme coin with given ID did not exist.
2. Added `AppError` struct for unified error handling across layers.
3. Updated service layer to return error when a meme coin is not found.
4. Adjusted handler to return proper HTTP error status via `HandleError`.
5. Changed repository update method to return *gorm.DB for error propagation.

# Why

1. To ensure API responses reflect the correct status when resources are not found.
2. To establish a maintainable and consistent error handling approach for the codebase.
