### PR TITLE
fix: handle poke request for non-existent meme coin

### DIFF
--- a/internal/handler/meme_coin_handler.go
+++ b/internal/handler/meme_coin_handler.go
@@ -152,12 +152,8 @@ func PokeMemeCoin(c *gin.Context) {
 	}
 
 	if err := service.PokeMemeCoin(uint(id)); err != nil {
-		log.Printf("Failed to poke meme coin: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{
-			"code":    500,
-			"message": "Failed to poke meme coin",
-			"data":    nil,
-		})
+		log.Printf("Failed to delete meme coin: %v", err)
+		common.HandleError(c, err)
 		return
 	}
 

--- a/internal/repository/meme_coin_repository.go
+++ b/internal/repository/meme_coin_repository.go
@@ -29,8 +29,8 @@ func DeleteMemeCoin(id uint) *gorm.DB {
 	return database.DB.Delete(&model.MemeCoin{}, id)
 }
 
-func PokeMemeCoin(id uint) error {
+func PokeMemeCoin(id uint) *gorm.DB {
 	return database.DB.Model(&model.MemeCoin{}).
 		Where("id = ?", id).
-		UpdateColumn("popularity_score", gorm.Expr("popularity_score + ?", 1)).Error
+		UpdateColumn("popularity_score", gorm.Expr("popularity_score + ?", 1))
 }

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -59,5 +59,23 @@ func DeleteMemeCoin(id uint) error {
 }
 
 func PokeMemeCoin(id uint) error {
-	return repository.PokeMemeCoin(id)
+	result := repository.PokeMemeCoin(id)
+
+	if result.Error != nil {
+		return &common.AppError{
+			Code:    500,
+			Message: "Database error",
+			Data:    nil,
+		}
+	}
+
+	if result.RowsAffected == 0 {
+		return &common.AppError{
+			Code:    404,
+			Message: "Meme coin not found",
+			Data:    nil,
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
# What

1. Updated PokeMemeCoin API to check if the meme coin exists before processing.
2. Modified repository and service layers to return an error when not found.
3. Updated handler to return appropriate error response using unified error handler.

# Why

1. To prevent incorrect 200 responses when targeting a non-existent resource.
2. To maintain consistent and reliable API behavior.
