### PR TITLE
refactor: use DTOs for meme coin request handling

### DIFF
--- a/internal/dtos/meme_coin_request.go
+++ b/internal/dtos/meme_coin_request.go
@@ -3,3 +3,8 @@ package dtos
 type UpdateMemeCoinRequest struct {
 	Description string `json:"description"`
 }
+
+type CreateMemeCoinRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}

--- a/internal/service/meme_coin_service.go
+++ b/internal/service/meme_coin_service.go
@@ -2,20 +2,34 @@ package service
 
 import (
 	"github.com/HackHow/meme-coin/internal/common"
+	"github.com/HackHow/meme-coin/internal/dtos"
 	"github.com/HackHow/meme-coin/internal/model"
 	"github.com/HackHow/meme-coin/internal/repository"
 )
 
-func CreateMemeCoin(coin *model.MemeCoin) error {
-	return repository.CreateMemeCoin(coin)
+func CreateMemeCoin(input dtos.CreateMemeCoinRequest) error {
+	coin := &model.MemeCoin{
+		Name:        input.Name,
+		Description: input.Description,
+	}
+
+	if err := repository.CreateMemeCoin(coin); err != nil {
+		return &common.AppError{
+			Code:    500,
+			Message: "Database error",
+			Data:    nil,
+		}
+	}
+
+	return nil
 }
 
 func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 	return repository.GetMemeCoin(id)
 }
 
-func UpdateMemeCoin(id uint, description string) error {
-	result := repository.UpdateMemeCoin(id, description)
+func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
+	result := repository.UpdateMemeCoin(id, input.Description)
 
 	if result.Error != nil {
 		return &common.AppError{


### PR DESCRIPTION
# What

1. Introduced `CreateMemeCoinRequest` struct in `meme_coin_request.go`.
2. Refactored `CreateMemeCoin` and `UpdateMemeCoin` handlers to bind input to DTOs.
3. Updated corresponding service methods to accept DTOs instead of model pointers.
4. Improved error handling consistency in service and handler layers.

# Why

1. To decouple API layer from internal data models.
2. To align with clean architecture practices using DTOs for request validation and input.
3. To improve code maintainability, readability, and testability.
