### PR TITLE
refactor: rename internal folders to plural and fix import paths

### DIFF
--- a/internal/handlers/meme_coin_handler.go
+++ b/internal/handlers/meme_coin_handler.go
@@ -1,4 +1,4 @@
-package handler
+package handlers
 
 import (
 	"log"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/HackHow/meme-coin/internal/common"
 	"github.com/HackHow/meme-coin/internal/dtos"
-	"github.com/HackHow/meme-coin/internal/service"
+	"github.com/HackHow/meme-coin/internal/services"
 )
 
 func CreateMemeCoin(c *gin.Context) {
@@ -23,7 +23,7 @@ func CreateMemeCoin(c *gin.Context) {
 		return
 	}
 
-	if err := service.CreateMemeCoin(req); err != nil {
+	if err := services.CreateMemeCoin(req); err != nil {
 		log.Printf("Failed to create meme coin: %v", err)
 		common.HandleError(c, err)
 		return
@@ -48,7 +48,7 @@ func GetMemeCoin(c *gin.Context) {
 		return
 	}
 
-	coin, err := service.GetMemeCoin(uint(id))
+	coin, err := services.GetMemeCoin(uint(id))
 	if err != nil {
 		log.Printf("Failed to get meme coin: %v", err)
 		common.HandleError(c, err)
@@ -91,7 +91,7 @@ func UpdateMemeCoin(c *gin.Context) {
 		return
 	}
 
-	err = service.UpdateMemeCoin(uint(id), req)
+	err = services.UpdateMemeCoin(uint(id), req)
 	if err != nil {
 		log.Printf("Failed to update meme coin: %v", err)
 		common.HandleError(c, err)
@@ -117,7 +117,7 @@ func DeleteMemeCoin(c *gin.Context) {
 		return
 	}
 
-	if err := service.DeleteMemeCoin(uint(id)); err != nil {
+	if err := services.DeleteMemeCoin(uint(id)); err != nil {
 		log.Printf("Failed to delete meme coin: %v", err)
 		common.HandleError(c, err)
 		return
@@ -142,7 +142,7 @@ func PokeMemeCoin(c *gin.Context) {
 		return
 	}
 
-	if err := service.PokeMemeCoin(uint(id)); err != nil {
+	if err := services.PokeMemeCoin(uint(id)); err != nil {
 		log.Printf("Failed to delete meme coin: %v", err)
 		common.HandleError(c, err)
 		return

--- a/internal/models/meme_coin.go
+++ b/internal/models/meme_coin.go
@@ -1,4 +1,4 @@
-package model
+package models
 
 import (
 	"time"

--- a/internal/repositories/meme_coin_repository.go
+++ b/internal/repositories/meme_coin_repository.go
@@ -1,17 +1,17 @@
-package repository
+package repositories
 
 import (
-	"github.com/HackHow/meme-coin/internal/model"
+	"github.com/HackHow/meme-coin/internal/models"
 	"github.com/HackHow/meme-coin/pkg/database"
 	"gorm.io/gorm"
 )
 
-func CreateMemeCoin(coin *model.MemeCoin) error {
+func CreateMemeCoin(coin *models.MemeCoin) error {
 	return database.DB.Create(coin).Error
 }
 
-func GetMemeCoin(id uint) (*model.MemeCoin, error) {
-	var coin model.MemeCoin
+func GetMemeCoin(id uint) (*models.MemeCoin, error) {
+	var coin models.MemeCoin
 	if err := database.DB.First(&coin, id).Error; err != nil {
 		return nil, err
 	}
@@ -20,17 +20,17 @@ func GetMemeCoin(id uint) (*model.MemeCoin, error) {
 }
 
 func UpdateMemeCoin(id uint, description string) *gorm.DB {
-	return database.DB.Model(&model.MemeCoin{}).
+	return database.DB.Model(&models.MemeCoin{}).
 		Where("id = ?", id).
 		Update("description", description)
 }
 
 func DeleteMemeCoin(id uint) *gorm.DB {
-	return database.DB.Delete(&model.MemeCoin{}, id)
+	return database.DB.Delete(&models.MemeCoin{}, id)
 }
 
 func PokeMemeCoin(id uint) *gorm.DB {
-	return database.DB.Model(&model.MemeCoin{}).
+	return database.DB.Model(&models.MemeCoin{}).
 		Where("id = ?", id).
 		UpdateColumn("popularity_score", gorm.Expr("popularity_score + ?", 1))
 }

--- a/internal/routers/router.go
+++ b/internal/routers/router.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/HackHow/meme-coin/config"
-	"github.com/HackHow/meme-coin/internal/handler"
+	"github.com/HackHow/meme-coin/internal/handlers"
 )
 
 func InitRouter() *gin.Engine {
@@ -15,11 +15,11 @@ func InitRouter() *gin.Engine {
 
 	api := r.Group("/api/" + config.AppConfig.APIVersion)
 	{
-		api.POST("/meme-coins", handler.CreateMemeCoin)
-		api.GET("/meme-coins/:id", handler.GetMemeCoin)
-		api.PATCH("/meme-coins/:id", handler.UpdateMemeCoin)
-		api.DELETE("/meme-coins/:id", handler.DeleteMemeCoin)
-		api.POST("/meme-coins/:id/poke", handler.PokeMemeCoin)
+		api.POST("/meme-coins", handlers.CreateMemeCoin)
+		api.GET("/meme-coins/:id", handlers.GetMemeCoin)
+		api.PATCH("/meme-coins/:id", handlers.UpdateMemeCoin)
+		api.DELETE("/meme-coins/:id", handlers.DeleteMemeCoin)
+		api.POST("/meme-coins/:id/poke", handlers.PokeMemeCoin)
 	}
 
 	r.GET("/healthz", func(c *gin.Context) {

--- a/internal/services/meme_coin_service.go
+++ b/internal/services/meme_coin_service.go
@@ -1,19 +1,19 @@
-package service
+package services
 
 import (
 	"github.com/HackHow/meme-coin/internal/common"
 	"github.com/HackHow/meme-coin/internal/dtos"
-	"github.com/HackHow/meme-coin/internal/model"
-	"github.com/HackHow/meme-coin/internal/repository"
+	"github.com/HackHow/meme-coin/internal/models"
+	"github.com/HackHow/meme-coin/internal/repositories"
 )
 
 func CreateMemeCoin(input dtos.CreateMemeCoinRequest) error {
-	coin := &model.MemeCoin{
+	coin := &models.MemeCoin{
 		Name:        input.Name,
 		Description: input.Description,
 	}
 
-	if err := repository.CreateMemeCoin(coin); err != nil {
+	if err := repositories.CreateMemeCoin(coin); err != nil {
 		return &common.AppError{
 			Code:    500,
 			Message: "Database error",
@@ -24,12 +24,12 @@ func CreateMemeCoin(input dtos.CreateMemeCoinRequest) error {
 	return nil
 }
 
-func GetMemeCoin(id uint) (*model.MemeCoin, error) {
-	return repository.GetMemeCoin(id)
+func GetMemeCoin(id uint) (*models.MemeCoin, error) {
+	return repositories.GetMemeCoin(id)
 }
 
 func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
-	result := repository.UpdateMemeCoin(id, input.Description)
+	result := repositories.UpdateMemeCoin(id, input.Description)
 
 	if result.Error != nil {
 		return &common.AppError{
@@ -51,7 +51,7 @@ func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
 }
 
 func DeleteMemeCoin(id uint) error {
-	result := repository.DeleteMemeCoin(id)
+	result := repositories.DeleteMemeCoin(id)
 
 	if result.Error != nil {
 		return &common.AppError{
@@ -73,7 +73,7 @@ func DeleteMemeCoin(id uint) error {
 }
 
 func PokeMemeCoin(id uint) error {
-	result := repository.PokeMemeCoin(id)
+	result := repositories.PokeMemeCoin(id)
 
 	if result.Error != nil {
 		return &common.AppError{


### PR DESCRIPTION
# What

1. Renamed internal package folders from singular to plural:
   - `handler` → `handlers`
   - `model` → `models`
   - `repository` → `repositories`
   - `service` → `services`
2. Updated all import paths accordingly across affected files.

# Why

1. To follow naming conventions and improve consistency across the codebase.
2. To make package structures more intuitive and easier to navigate.
