### PR TITLE
docs: fix health check endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ docker-compose up -d
 3. Verify application is running via API tools such as Postman or cURL:
 
 ```
-GET http://localhost:8080/health
+curl --location 'http://localhost:8080/healthz'
 ```
 
 ### Locally


### PR DESCRIPTION
# What

1. Updated README health check example from `GET /health` to `curl --location 'http://localhost:8080/healthz'`.

# Why

1. To reflect the actual implemented route and ensure developers can verify server health accurately.
