### PR TITLE
fix: validate meme coin creation and return correct error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ go run ./cmd/server/main.go
 6. Verify local application running via API tools such as Postman or cURL:
 
 ```
-GET http://localhost:8080/health
+curl --location 'http://localhost:8080/healthz'
 ```
 
 ## API Overview

--- a/internal/dtos/meme_coin_request.go
+++ b/internal/dtos/meme_coin_request.go
@@ -5,6 +5,6 @@ type UpdateMemeCoinRequest struct {
 }
 
 type CreateMemeCoinRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
 }

--- a/internal/handlers/meme_coin_handler.go
+++ b/internal/handlers/meme_coin_handler.go
@@ -126,7 +126,7 @@ func DeleteMemeCoin(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"code":    200,
 		"message": "Meme coin deleted successfully",
-		"data":    gin.H{"id": id},
+		"data":    nil,
 	})
 }
 

--- a/internal/repositories/meme_coin_repository.go
+++ b/internal/repositories/meme_coin_repository.go
@@ -10,13 +10,11 @@ func CreateMemeCoin(coin *models.MemeCoin) error {
 	return database.DB.Create(coin).Error
 }
 
-func GetMemeCoin(id uint) (*models.MemeCoin, error) {
+func GetMemeCoin(id uint) (*models.MemeCoin, *gorm.DB) {
 	var coin models.MemeCoin
-	if err := database.DB.First(&coin, id).Error; err != nil {
-		return nil, err
-	}
+	result := database.DB.First(&coin, id)
 
-	return &coin, nil
+	return &coin, result
 }
 
 func UpdateMemeCoin(id uint, description string) *gorm.DB {

--- a/internal/services/meme_coin_service.go
+++ b/internal/services/meme_coin_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"strings"
+
 	"github.com/HackHow/meme-coin/internal/common"
 	"github.com/HackHow/meme-coin/internal/dtos"
 	"github.com/HackHow/meme-coin/internal/models"
@@ -10,10 +12,23 @@ import (
 func CreateMemeCoin(input dtos.CreateMemeCoinRequest) error {
 	coin := &models.MemeCoin{
 		Name:        input.Name,
-		Description: input.Description,
+		Description: "",
 	}
 
-	if err := repositories.CreateMemeCoin(coin); err != nil {
+	if input.Description != nil {
+		coin.Description = *input.Description
+	}
+
+	err := repositories.CreateMemeCoin(coin)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "UNIQUE") {
+			return &common.AppError{
+				Code:    409,
+				Message: "Meme coin name already exists",
+				Data:    nil,
+			}
+		}
+
 		return &common.AppError{
 			Code:    500,
 			Message: "Database error",
@@ -25,24 +40,42 @@ func CreateMemeCoin(input dtos.CreateMemeCoinRequest) error {
 }
 
 func GetMemeCoin(id uint) (*models.MemeCoin, error) {
-	return repositories.GetMemeCoin(id)
-}
+	coin, result := repositories.GetMemeCoin(id)
 
-func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
-	result := repositories.UpdateMemeCoin(id, input.Description)
+	if result.RowsAffected == 0 {
+		return nil, &common.AppError{
+			Code:    404,
+			Message: "Meme coin not found",
+			Data:    nil,
+		}
+	}
 
 	if result.Error != nil {
-		return &common.AppError{
+		return nil, &common.AppError{
 			Code:    500,
 			Message: "Database error",
 			Data:    nil,
 		}
 	}
 
+	return coin, nil
+}
+
+func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
+	result := repositories.UpdateMemeCoin(id, input.Description)
+
 	if result.RowsAffected == 0 {
 		return &common.AppError{
 			Code:    404,
 			Message: "Meme coin not found",
+			Data:    nil,
+		}
+	}
+
+	if result.Error != nil {
+		return &common.AppError{
+			Code:    500,
+			Message: "Database error",
 			Data:    nil,
 		}
 	}
@@ -53,18 +86,18 @@ func UpdateMemeCoin(id uint, input dtos.UpdateMemeCoinRequest) error {
 func DeleteMemeCoin(id uint) error {
 	result := repositories.DeleteMemeCoin(id)
 
-	if result.Error != nil {
-		return &common.AppError{
-			Code:    500,
-			Message: "Database error",
-			Data:    nil,
-		}
-	}
-
 	if result.RowsAffected == 0 {
 		return &common.AppError{
 			Code:    404,
 			Message: "Meme coin not found",
+			Data:    nil,
+		}
+	}
+
+	if result.Error != nil {
+		return &common.AppError{
+			Code:    500,
+			Message: "Database error",
 			Data:    nil,
 		}
 	}


### PR DESCRIPTION
# What

1. Fixed Create Meme Coin:
   - Return 409 if coin name already exists.
   - Allow `description` to be optional via `*string` type.
2. Fixed Get Meme Coin:
   - Return 404 instead of 500 when ID is not found.
3. Fixed Update/Delete Meme Coin:
   - Swapped 500 and 404 validation order to prioritize "not found" error.
4. Updated README:
   - Changed health check example from `GET` to `curl --location 'http://localhost:8080/healthz'`.

# Why

1. To improve API correctness and align with RESTful standards.
2. To ensure optional fields like `description` are handled properly.
3. To make error responses clearer and more consistent for client developers.
4. To help developers verify server health using accurate endpoint instructions.
